### PR TITLE
Create Gantt visualization

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,7 +39,7 @@ const zone1: D3ZonePainter = {
     return true
   },
   getHeight: function () {
-    return (barHeight + barGap) * this.data.length - barGap // Remove gap from last bar, for true height
+    return (barHeight + barGap) * this.data.length - barGap + 1 // Remove gap from last bar, plus border width, for true height
   },
   paintData: async function (container, x) {
     container
@@ -63,6 +63,8 @@ const zone1: D3ZonePainter = {
 
 // Draw dot-style markers, only taking up one row of space
 const dotRadius = 10
+const noon = new Date()
+noon.setHours(12, 0, 0)
 const zone2: D3ZonePainter = {
   data: [],
   title: 'Dots',
@@ -70,25 +72,30 @@ const zone2: D3ZonePainter = {
     // In a real scenario, this would likely be an API call. Using static fixture here as an example
     this.data = [
       {
-        date: daysShift(now, -20),
+        date: daysShift(noon, -20),
         label: 'A',
       },
       {
-        date: daysShift(now, -19),
+        date: daysShift(noon, -19),
         label: 'A',
       },
       {
-        date: daysShift(now, -12),
+        date: daysShift(noon, -12),
         label: 'B',
       },
       {
-        date: daysShift(now, -4),
+        date: daysShift(noon, -4),
         label: 'C',
       },
       {
-        date: daysShift(now, 2),
+        date: daysShift(noon, 2),
         label: 'A',
         style: 'fill: #AAF',
+      },
+      {
+        date: daysShift(noon, 4),
+        label: 'C',
+        style: 'fill: #AFA',
       },
     ]
     return true

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,137 @@
 'use client'
 
-import GantTimeline from '@/components/GanttTimeline'
+import GantTimeline, { D3ZonePainter } from '@/components/GanttTimeline'
+
+function daysShift(start: Date, daysDelta: number): Date {
+  const d = new Date(start.getTime())
+  d.setDate(d.getDate() + daysDelta)
+  return d
+}
+
+const now = new Date()
+
+// Draw box-style visualization, taking up multiple rows
+const barHeight = 10
+const barGap = 5
+const zone1: D3ZonePainter = {
+  data: [],
+  title: 'Boxes',
+  init: async function () {
+    // In a real scenario, this would likely be an API call. Using static fixture here as an example
+    this.data = [
+      {
+        startDate: daysShift(now, -5),
+        endDate: now,
+      },
+      {
+        startDate: daysShift(now, -15),
+        endDate: daysShift(now, -1),
+      },
+      {
+        startDate: daysShift(now, -2),
+        endDate: daysShift(now, 3),
+      },
+      {
+        startDate: daysShift(now, -50),
+        endDate: daysShift(now, -7),
+      },
+    ]
+    return true
+  },
+  getHeight: function () {
+    return (barHeight + barGap) * this.data.length - barGap // Remove gap from last bar, for true height
+  },
+  paintData: async function (container, x) {
+    container
+      .attr('style', 'stroke: #008; stroke-width: 1px; fill: #00F; fill-opacity: 0.1')
+      .selectAll('rect')
+      .data(this.data)
+      .join(
+        enter =>
+          enter
+            .append('rect')
+            .attr('x', d => Math.floor(x(d.startDate)) + 0.5)
+            .attr('y', (d, i) => i * (barHeight + barGap) + 0.5)
+            .attr('width', d => x(d.endDate) - x(d.startDate))
+            .attr('height', barHeight),
+        update =>
+          update.attr('x', d => x(d.startDate)).attr('width', d => x(d.endDate) - x(d.startDate)),
+      )
+    return true
+  },
+}
+
+// Draw dot-style markers, only taking up one row of space
+const dotRadius = 10
+const zone2: D3ZonePainter = {
+  data: [],
+  title: 'Dots',
+  init: async function () {
+    // In a real scenario, this would likely be an API call. Using static fixture here as an example
+    this.data = [
+      {
+        date: daysShift(now, -20),
+        label: 'A',
+      },
+      {
+        date: daysShift(now, -19),
+        label: 'A',
+      },
+      {
+        date: daysShift(now, -12),
+        label: 'B',
+      },
+      {
+        date: daysShift(now, -4),
+        label: 'C',
+      },
+      {
+        date: daysShift(now, 2),
+        label: 'A',
+        style: 'fill: #AAF',
+      },
+    ]
+    return true
+  },
+  getHeight: function () {
+    return dotRadius * 2
+  },
+  paintData: async function (container, x) {
+    container
+      .attr('style', 'fill: #aaa;')
+      .selectAll('circle')
+      .data(this.data)
+      .join(enter =>
+        enter
+          .append('g')
+          .attr('transform', d => `translate(${Math.floor(x(d.date))}, ${dotRadius})`)
+          .call(g => {
+            g.append('circle')
+              .attr('cx', 0)
+              .attr('cy', 0)
+              .attr('r', dotRadius)
+              .attr('style', d => d.style)
+            g.append('text')
+              .attr('text-anchor', 'middle')
+              .attr(
+                'style',
+                'fill: #000; font-size:12px; font-family: "Gill Sans", "Gill Sans MT", Calibri, "Trebuchet MS", sans-serif;',
+              )
+              .attr('x', 0)
+              .attr('y', 4)
+              .text(d => d.label)
+          }),
+      )
+    return true
+  },
+}
 
 export default function Home() {
   return (
     <main>
       <h1>D3 Dashboard Widgets</h1>
       <div style={{ width: '100%' }}>
-        <GantTimeline />
+        <GantTimeline zones={[zone1, zone2]} />
       </div>
     </main>
   )

--- a/components/GanttTimeline.module.css
+++ b/components/GanttTimeline.module.css
@@ -1,0 +1,17 @@
+.headerDays {
+  font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+  font-size: 12px;
+}
+.headerMonths {
+  font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+  font-size: 16px;
+}
+
+.zoneBg {
+  stroke: #880; stroke-width: 1px; fill: #000; fill-opacity: 0.1
+}
+.headerZone {
+  font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+  font-weight: bold;
+  font-size: 14px;
+}

--- a/components/GanttTimeline.tsx
+++ b/components/GanttTimeline.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect } from 'react'
 import * as d3 from 'd3'
+import styles from './GanttTimeline.module.css'
 
 const chartConfig = {
   height: 400,
@@ -7,9 +8,13 @@ const chartConfig = {
   margin: {
     headerMonths: 20,
     headerDays: 40,
+    zone: 5,
+  },
+  padding: {
+    zone: 10,
   },
 }
-const MS_IN_ONE_DAY = 1000 * 60 * 60 * 24
+
 const monthLabel = d3.utcFormat('%b %Y')
 
 function daysShift(start: Date, daysDelta: number): Date {
@@ -22,14 +27,17 @@ function daysShift(start: Date, daysDelta: number): Date {
  * Modular components that are responsible for rendering portions of the visualization
  */
 export interface D3ZonePainter {
+  data: any[]
+  title: string
+  init: () => Promise<boolean>
   getHeight: () => number
   paintData: (
     container: d3.Selection<SVGGElement, null, any, any>,
-    x: d3.ScaleTime<Date, number>,
-  ) => void
+    x: d3.ScaleTime<number, number>,
+  ) => Promise<boolean>
 }
 
-export default function GantTimeline() {
+export default function GantTimeline({ zones }: { zones: D3ZonePainter[] }) {
   const svgRef = useRef<SVGSVGElement | null>(null)
 
   // Create D3 scale for initial state of the visualization
@@ -54,20 +62,22 @@ export default function GantTimeline() {
     chartConfig.width = svg.node()!.clientWidth
     initialX.range([0, chartConfig.width])
 
-    // Draw initial inteface elements
+    // Paint initial inteface elements
     const dayTicks = initialX.ticks(d3.timeDay)
     const dayWidth = initialX(dayTicks[1]) - initialX(dayTicks[0])
+    // Paint lines between each day
     svg
       .select('#grid')
       .selectAll<SVGLineElement, Date>('line')
       .data(dayTicks, d => d.getTime())
       .join('line')
       .attr('transform', d => `translate(${Math.floor(initialX(d))},0)`)
-      .attr('style', 'stroke: #CCC; stroke-width: 1px')
+      .attr('style', d => `stroke: ${d.getDay() == 0 ? '#555' : '#CCC'}; stroke-width: 1px`) // Draw darker lines to start each week
       .attr('x1', 0)
       .attr('x2', 0)
       .attr('y1', chartConfig.margin.headerMonths + 5)
       .attr('y2', chartConfig.height)
+    // Paint numbers for each calendar day
     svg
       .select('#axis')
       .selectAll<SVGGElement, Date>('g.day')
@@ -76,11 +86,13 @@ export default function GantTimeline() {
       .attr('class', 'day')
       .attr('transform', d => `translate(${Math.floor(initialX(d))},0)`)
       .append('text')
+      .attr('class', styles.headerDays)
       .attr('x', dayWidth / 2)
       .attr('text-anchor', 'middle')
       .attr('y', chartConfig.margin.headerDays)
       .text(d => d.getDate())
 
+    // Paint thicker lines and labels for each month
     const monthTicks = initialX.ticks(d3.timeMonth)
     svg
       .select('#axis')
@@ -91,18 +103,85 @@ export default function GantTimeline() {
       .attr('transform', d => `translate(${Math.floor(initialX(d))},0)`)
       .call(g => {
         g.append('line')
-          .attr('style', 'stroke: #AAA; stroke-width: 2px')
+          .attr('style', 'stroke: #555; stroke-width: 2px')
           .attr('x1', 0)
           .attr('x2', 0)
           .attr('y1', 0)
           .attr('y2', chartConfig.height)
         g.append('text')
+          .attr('class', styles.headerMonths)
           .attr('x', 5)
           .attr('y', chartConfig.margin.headerMonths)
           .text(d => monthLabel(d))
       })
 
+    // Initialize zones
+    await Promise.all(zones.map(z => z.init()))
+
     // Draw initial data into zones
+    const zoneWrapper = svg.select('#zones')
+    zoneWrapper.selectAll('*').remove()
+
+    // How tall is the data plot of each zone?
+    const heights = zones.map(z => z.getHeight())
+
+    // Track heights as we draw down the visualization
+    const cumulativeOffset: number[] = []
+    const zoneHeaderHeight = chartConfig.padding.zone + 14
+    await Promise.all(
+      zones.map((z, i) => {
+        // Create empty container for this zone
+        const c = zoneWrapper.append('g').attr('id', `zone-${i}`)
+
+        // For this chart type, each zone gets a boundary and a title (as an example, to be visible where the containers are), drawn here by the chart controller.
+        // Since it is the same for each zone, it's done here rather than requiring boilerplate in each zone definition
+
+        // Position the zone container
+        const priorZoneHeight =
+          i == 0
+            ? 0
+            : zoneHeaderHeight +
+              chartConfig.padding.zone +
+              heights[i - 1] +
+              chartConfig.padding.zone +
+              chartConfig.margin.zone
+        const verticalOffset = i == 0 ? 0 : cumulativeOffset[i - 1] + priorZoneHeight
+        cumulativeOffset[i] = verticalOffset
+        c.attr('transform', `translate(0,${verticalOffset + chartConfig.margin.headerDays + 10})`)
+
+        // Draw boundary around the zone
+        c.append('rect')
+          .attr('class', styles.zoneBg)
+          .attr('x', chartConfig.margin.zone)
+          .attr('y', 0)
+          .attr('width', chartConfig.width - chartConfig.margin.zone * 2)
+          .attr(
+            'height',
+            zoneHeaderHeight + chartConfig.padding.zone + heights[i] + chartConfig.padding.zone,
+          )
+        // Draw title for the zone
+        c.append('rect')
+          .attr('x', chartConfig.margin.zone)
+          .attr('y', 0)
+          .attr('width', chartConfig.width - chartConfig.margin.zone * 2)
+          .attr('height', zoneHeaderHeight)
+          .attr('style', 'fill: #000; fill-opacity: 0.1')
+        c.append('text')
+          .attr('class', styles.headerZone)
+          .attr('x', chartConfig.padding.zone)
+          .attr('y', zoneHeaderHeight - 7)
+          .text(z.title)
+
+        // Container for actual data needs to have a translate X component of zero, so that the Scale has a proper result
+        return z.paintData(
+          c
+            .append('g')
+            .attr('class', 'data')
+            .attr('transform', `translate(0, ${zoneHeaderHeight + chartConfig.padding.zone})`),
+          initialX,
+        )
+      }),
+    )
   }
 
   useEffect(() => {
@@ -113,7 +192,7 @@ export default function GantTimeline() {
   return (
     <svg ref={svgRef} style={{ width: '100%', height: '400px', background: '#FFC' }}>
       <g id="grid" />
-      <g id="data" />
+      <g id="zones" />
       <g id="axis" />
     </svg>
   )


### PR DESCRIPTION
Fleshing out the idea I had for how a visualization can have "zones" and the logic for how each zone gets populated can be handed off to separate logic classes.

This is an example that is a Gantt-like chart (it has a horizontal time axis, and its primary visual is a series of rectangles that show time intervals on it). This example visual stacks up two different zones, each of which have very different visual appearances. The first is the Gantt-like rectangles, and the second is individual markers (like an "annotations" track).

<img width="1714" alt="Screenshot 2024-03-17 at 1 54 24 PM" src="https://github.com/ronin-alumni/d3-dashboard-widgets/assets/250250/64465511-412c-4fd2-b549-fb8a09122a4a">

The Gantt visualization component handles creating the different zone containers, with reference to the zone painters to tell how much vertical height they need. The Zone painters are responsible for getting their own data, and determining if it can be painted within the specified axis range. The Gantt visualization component defines clipping paths to keep zone painters from adding beyond the desired spaces.